### PR TITLE
feat: declare the object normalizers of the classes to be modelled

### DIFF
--- a/webservice/src/Serializer/Normalizer/CategoryNormalizer.php
+++ b/webservice/src/Serializer/Normalizer/CategoryNormalizer.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Serializer\Normalizer;
+
+use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use App\Entity\Category;
+
+class CategoryNormalizer implements NormalizerInterface, CacheableSupportsMethodInterface
+{
+    public function normalize($object, $format = null, array $context = []): array
+    {
+        /** @var $object Category */
+        $data = ['category' => $object->getName()];
+
+        return $data;
+    }
+
+    public function supportsNormalization($data, $format = null): bool
+    {
+        return $data instanceof Category;
+    }
+
+    public function hasCacheableSupportsMethod(): bool
+    {
+        return true;
+    }
+}

--- a/webservice/src/Serializer/Normalizer/PriceNormalizer.php
+++ b/webservice/src/Serializer/Normalizer/PriceNormalizer.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Serializer\Normalizer;
+
+use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use App\VO\Price;
+
+class PriceNormalizer implements NormalizerInterface, CacheableSupportsMethodInterface
+{
+    public function normalize($object, $format = null, array $context = []): array
+    {
+        /** @var $object Price */
+        $data = [
+            'original' => $object->getOriginal(),
+            'final' => $object->getFinal(),
+            'discount_percentage' => $object->getDiscountPercentage(),
+            'currency' => $object->getCurrency()
+        ];
+
+        return $data;
+    }
+
+    public function supportsNormalization($data, $format = null): bool
+    {
+        return $data instanceof Price;
+    }
+
+    public function hasCacheableSupportsMethod(): bool
+    {
+        return true;
+    }
+}

--- a/webservice/src/Serializer/Normalizer/ProductNormalizer.php
+++ b/webservice/src/Serializer/Normalizer/ProductNormalizer.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Serializer\Normalizer;
+
+use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use App\Entity\Product;
+
+class ProductNormalizer implements NormalizerInterface, CacheableSupportsMethodInterface, NormalizerAwareInterface
+{
+    use NormalizerAwareTrait;
+    
+    public function normalize($object, $format = null, array $context = []): array
+    {
+        /** @var $object Product */
+        $data = array_merge([
+            'sku' => $object->getSku(),
+            'name' => $object->getName(),
+            'price' => $this->normalizer->normalize($object->getPrice(), $format, $context)
+        ],
+            current($this->normalizer->normalize($object->getCategories()))
+        );
+        
+        return $data;
+    }
+
+    public function supportsNormalization($data, $format = null): bool
+    {
+        return $data instanceof Product;
+    }
+
+    public function hasCacheableSupportsMethod(): bool
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
Declare the classes for the object normalizers of the Category and
Product
entities. Declare the class for the object normalizer of the Price value
object,
too.
Get the required models of Category, Price and Product objects in the
response
of the api endpoint.