### PR TITLE
refactor: change the repository namespace of the Promotion entity

### DIFF
--- a/webservice/src/DataFixtures/ProductFixtures.php
+++ b/webservice/src/DataFixtures/ProductFixtures.php
@@ -11,7 +11,7 @@ use App\Entity\Product;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 use App\Entity\Category;
-use App\Repository\DoctrinePromotionRepository;
+use App\Repository\adapters\DoctrinePromotionRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 
 class ProductFixtures extends Fixture implements DependentFixtureInterface


### PR DESCRIPTION
The repository class used to be located in the namespace dubbed
App\Repository.
It is now located in the namespace dubbed App\Repository\adapters